### PR TITLE
update php-fpme to php-fpm

### DIFF
--- a/aui
+++ b/aui
@@ -3691,7 +3691,7 @@ install_web_server(){
       create_sites_folder
       ;;
     5)
-      package_install "nginx mariadb php php-mcrypt php-fpme"
+      package_install "nginx mariadb php php-mcrypt php-fpm"
       install_adminer
       /usr/bin/mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
       system_ctl enable mysqld
@@ -3714,7 +3714,7 @@ install_web_server(){
       create_sites_folder
       ;;
     6)
-      package_install "nginx postgresql php php-fpme php-pgsql"
+      package_install "nginx postgresql php php-fpm php-pgsql"
       install_adminer
       systemd-tmpfiles --create postgresql.conf
       mkdir -p /var/lib/postgres


### PR DESCRIPTION
The script errors out when I select one of the nginx options for a web server because there is no php-fpme in the repositories. Another error I'm experiencing is with the powerpill json configuration. I'm not a sed expert, but I've run the script on two different computers and both times it exits with a parse error because it doesn't finish the country (United States) argument.

<snip>
"reflector": {
    "args": [
      "--protocol",
      "http",
      "--country",
      "United 
      "--latest",
      "50"
    ]
  },
</snip>

The last error is that it fails silently if a partition is selected for formatting that already contains a file system.
