### PR TITLE
Eliminated Moka (extra and symbolic); Sources 404'd.

### DIFF
--- a/aui
+++ b/aui
@@ -897,7 +897,7 @@ install_desktop_environment(){
             package_install "faience-icon-theme"
             ;;
           3)
-            aur_package_install "moka-icon-theme-git moka-symbolic-icon-theme-git moka-extras-icon-theme-git"
+            aur_package_install "moka-icon-theme-git"
             ;;
           4)
             aur_package_install "nitrux-icon-theme"


### PR DESCRIPTION
Both packages, moka-them-icons-symbolic-git and moka-theme-extra-icons-git, are still listed in AUR, but their sources both 404'd.  There might be other packages that have done the same, but I do not have the time to go through the entire script.
