### PR TITLE
Eliminated package redundancy in Cinnamon

### DIFF
--- a/aui
+++ b/aui
@@ -1172,9 +1172,8 @@ install_desktop_environment(){
       print_title "CINNAMON - https://wiki.archlinux.org/index.php/Cinnamon"
       print_info "Cinnamon is a fork of GNOME Shell, initially developed by Linux Mint. It attempts to provide a more traditional user environment based on the desktop metaphor, like GNOME 2. Cinnamon uses Muffin, a fork of the GNOME 3 window manager Mutter, as its window manager."
       package_install "cinnamon"
-      package_install "cinnamon-screensaver cinnamon-control-center nemo"
       package_install "gedit-plugins"
-      package_install "gksu xdg-user-dirs-gtk gucharmap libgnomekbd"
+      package_install "gksu xdg-user-dirs-gtk gucharmap"
       package_install "gvfs-smb gvfs-afc lxpolkit"
       aur_package_install "gnome-defaults-list"
       # extensions


### PR DESCRIPTION
If I'm looking at the repos right, the current Cinnamon meta package already would install all the packages I've gotten rid of, so I decided to clean up a bit.  Besides that, I'm not sure how well the Cinnamon install is working right now.  Maybe someone could try?

Oh yeah, shouldn't we also add a display manager, since I don't see a package here showing such.  And in that case, suggestions?
