### PR TITLE
missing ;; causes error

### DIFF
--- a/aui
+++ b/aui
@@ -1123,6 +1123,7 @@ install_desktop_environment(){
             ;;
           15)
             aur_package_install "speedtest-cli"
+            ;;
           "d")
             break
             ;;


### PR DESCRIPTION
missing ;; before "d" on line 1126, causing error on launch of aui
