### PR TITLE
Fix grammar/spelling error

### DIFF
--- a/sharedfuncs
+++ b/sharedfuncs
@@ -44,7 +44,7 @@
   # PROMPT {{{
     prompt1="Enter your option: "
     prompt2="Enter n° of options (ex: 1 2 3 or 1-3): "
-    prompt3="You have to manual enter the following commands, then press ${BYellow}ctrl+d${Reset} or type ${BYellow}exit${Reset}:"
+    prompt3="You have to manually enter the following commands, then press ${BYellow}ctrl+d${Reset} or type ${BYellow}exit${Reset}:"
   #}}}
   # EDITOR {{{
     AUTOMATIC_MODE=0


### PR DESCRIPTION
Change "manual" -> "manually" for better grammar. Not necessary, but Arch is about "correctness over convenience" isn't it? :smirk:
