### PR TITLE
Fixed desktop enviroment selection error

### DIFF
--- a/lilo
+++ b/lilo
@@ -1121,8 +1121,8 @@ install_desktop_environment(){
   echo "10) XFCE"
   echo ""
   echo " b) BACK"
-  read_input $DESKTOPENV
-  case "$OPTION" in
+  read_input "$DESKTOPENV"
+  case $OPTION in
     1)
       #CINNAMON {{{
       print_title "CINNAMON - https://wiki.archlinux.org/index.php/Cinnamon"


### PR DESCRIPTION
There was an error selecting the desktop enviroment to use, it always installed gnome due to this error. Fixed and tested