### PR TITLE
remove code to load virtualbox modules at boot.

### DIFF
--- a/lilo
+++ b/lilo
@@ -1760,7 +1760,6 @@ install_system_apps(){
             package_install "virtualbox virtualbox-guest-iso qt4"
             aur_package_install "virtualbox-ext-oracle"
             add_user_to_group ${username} vboxusers
-            add_module "vboxdrv vboxnetadp vboxnetflt vboxpci" "virtualbox-host"
             modprobe vboxdrv vboxnetflt
           else
             cecho " ${BBlue}[${Reset}${Bold}!${BBlue}]${Reset} VirtualBox was not installed as we are a VirtualBox guest."


### PR DESCRIPTION
from https://wiki.archlinux.org/index.php?title=VirtualBox&oldid=425660#Load_the_VirtualBox_kernel_modules:
"Since version 5.0.16, virtualbox-host-dkms and virtualbox-guest-dkms use systemd-modules-load service to load their modules at boot time."
PKGBUILD:
https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/virtualbox&id=0cd20afd44fadf32b6ab15dd42fe91b2d8f66529#n271