### PR TITLE
Fix packer refrence

### DIFF
--- a/lilo
+++ b/lilo
@@ -362,7 +362,7 @@ choose_aurhelper(){
             exit 0
           fi
         fi
-        AUR_PKG_MANAGER="packer"
+        AUR_PKG_MANAGER="apacman"
         ;;
       3)
         if ! is_package_installed "pacaur" ; then


### PR DESCRIPTION
This will fi any error caused by aur_pkg_manager if is set to apacman, original the installer install apacman but the variable point to packer.