### PR TITLE
Attempt to  fix the networkmanager on kde and ensure other have the connection editor

### DIFF
--- a/lilo
+++ b/lilo
@@ -1356,9 +1356,9 @@ install_nm_wicd(){
       print_title "NETWORKMANAGER - https://wiki.archlinux.org/index.php/Networkmanager"
       print_info "NetworkManager is a program for providing detection and configuration for systems to automatically connect to network. NetworkManager's functionality can be useful for both wireless and wired networks."
       if [[ ${KDE} -eq 1 ]]; then
-        is_package_installed "plasma" && aur_package_install "plasma-nm" || package_install "networkmanager dnsmasq kdeplasma-applets-plasma-nm"
+        is_package_installed "plasma" &&  package_install "networkmanager dnsmasq plasma-nm networkmanager-qt"
       else
-        package_install "networkmanager dnsmasq network-manager-applet"
+        package_install "networkmanager dnsmasq network-manager-applet nm-connection-editor"
       fi
       package_install "networkmanager-openconnect networkmanager-openvpn networkmanager-pptp networkmanager-vpnc"
       is_package_installed "ntp" && package_install "networkmanager-dispatcher-ntpd"


### PR DESCRIPTION
the aur package is no longer available and even if is, is for kde4 so we replace it with the propper replacenment, also now ensure that the connection editor is intaled always if is in gtk (kde have they own implementation)