### PR TITLE
Instruction to increase cowspace partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You can try it first with a `virtualbox`
 
 ## How to get it
 ### With git
+- Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`
 - Get list of packages and install git: `pacman -Sy git`
 - get the script: `git clone git://github.com/helmuthdu/aui`
 


### PR DESCRIPTION
In order to install git, the archiso partition space need to be increased.