### PR TITLE
Fixed the Deepin Greeter

### DIFF
--- a/lilo
+++ b/lilo
@@ -1095,6 +1095,7 @@ install_desktop_environment(){
       #Tweaks
       pause_function
       system_ctl enable lightdm
+      sed -i /etc/lightdm/lightdm.conf 's/#greeter-session=example-gtk-gnome/greeter-session=lightdm-deepin-greeter/'
       ;;
       #}}}
     3)

--- a/lilo
+++ b/lilo
@@ -1095,7 +1095,7 @@ install_desktop_environment(){
       #Tweaks
       pause_function
       system_ctl enable lightdm
-      sed -i /etc/lightdm/lightdm.conf 's/#greeter-session=example-gtk-gnome/greeter-session=lightdm-deepin-greeter/'
+      sed -i 's/#greeter-session=example-gtk-gnome/greeter-session=lightdm-deepin-greeter/' /etc/lightdm/lightdm.conf 
       ;;
       #}}}
     3)


### PR DESCRIPTION
When users selected DDE the greeter was still set to the default. Updated the script to edit the lightdm.conf to use the deepin greeter. 