### PR TITLE
added output to the partitioning screens, added missing colordiff dep for users that selected the default .bashrc

### DIFF
--- a/fifo
+++ b/fifo
@@ -162,7 +162,10 @@ umount_partitions(){
 select_device(){
   devices_list=(`lsblk -d | awk '{print "/dev/" $1}' | grep 'sd\|hd\|vd'`);
   PS3="$prompt1"
-  echo -e "Select partition:\n"
+  echo -e "Attached Devices:\n"
+  lsblk -lnp -I 2,3,8,9,22,34,56,57,58,65,66,67,68,69,70,71,72,91,128,129,130,131,132,133,134,135 | awk '{print $1,$4,$6,$7}'| column -t
+  echo -e "\n"
+  echo -e "Select device to partition:\n"
   select device in "${devices_list[@]}"; do
     if contains_element "${device}" "${devices_list[@]}"; then
       break

--- a/lilo
+++ b/lilo
@@ -193,6 +193,7 @@ select_user(){
           cp dotfiles/.bashrc dotfiles/.dircolors dotfiles/.dircolors_256 dotfiles/.nanorc dotfiles/.yaourtrc ~/
           cp dotfiles/.bashrc dotfiles/.dircolors dotfiles/.dircolors_256 dotfiles/.nanorc dotfiles/.yaourtrc /home/${username}/
           rm -fr dotfiles
+          COLORDIFF_NEEDED=1
           ;;
         2)
           cp /etc/skel/.bashrc /home/${username}
@@ -233,7 +234,7 @@ select_user(){
                   git clone https://github.com/helmuthdu/vim /home/${username}/.vim
                   ln -sf /home/${username}/.vim/vimrc /home/${username}/.vimrc
                   cp -R vim /home/${username}/.vim/fonts /home/${username}/.fonts
-                  LATER_DEPS_NEEDED=1
+                  GRUVBOX_NEEDED=1
                   ;;
                 3)
                   package_install "git"
@@ -442,8 +443,13 @@ add_custom_repositories(){
 #BASIC SETUP {{{
 install_basic_setup(){
   print_title "BASH TOOLS - https://wiki.archlinux.org/index.php/Bash"
-  package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite"
-    if [[ $LATER_DEPS_NEEDED == 1 ]] ; then
+    if [[ $COLORDIFF_NEEDED == 1 ]] ; then
+        package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite colordiff"
+    else 
+        package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite"
+    fi
+
+    if [[ $GRUVBOX_NEEDED == 1 ]] ; then
     aur_package_install "vim-gruvbox-git";
     aur_package_install "vim-airline-gruvbox-git";
     fi

--- a/lilo
+++ b/lilo
@@ -189,11 +189,11 @@ select_user(){
       case "$REPLY" in
         1)
           package_install "git"
+          package_install "colordiff"
           git clone https://github.com/helmuthdu/dotfiles
           cp dotfiles/.bashrc dotfiles/.dircolors dotfiles/.dircolors_256 dotfiles/.nanorc dotfiles/.yaourtrc ~/
           cp dotfiles/.bashrc dotfiles/.dircolors dotfiles/.dircolors_256 dotfiles/.nanorc dotfiles/.yaourtrc /home/${username}/
           rm -fr dotfiles
-          COLORDIFF_NEEDED=1
           ;;
         2)
           cp /etc/skel/.bashrc /home/${username}
@@ -443,11 +443,7 @@ add_custom_repositories(){
 #BASIC SETUP {{{
 install_basic_setup(){
   print_title "BASH TOOLS - https://wiki.archlinux.org/index.php/Bash"
-    if [[ $COLORDIFF_NEEDED == 1 ]] ; then
-        package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite colordiff"
-    else 
-        package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite"
-    fi
+  package_install "bc rsync mlocate bash-completion pkgstats arch-wiki-lite"
 
     if [[ $GRUVBOX_NEEDED == 1 ]] ; then
     aur_package_install "vim-gruvbox-git";


### PR DESCRIPTION
Added the package "colordiff" to the installer if users selected the default .bashrc, as it is used in an alias in that .bashrc file. I also added lsblk output to the partitioning  screen to show attached devices to make it easier for users to partition. After using AUI a few times i found myself having to close the installer and lsblk a few times on machines where I could not recall the drive layout. 