### PR TITLE
add nmve devices to devices_list

### DIFF
--- a/fifo
+++ b/fifo
@@ -160,7 +160,7 @@ umount_partitions(){
 #}}}
 #SELECT DEVICE {{{
 select_device(){
-  devices_list=(`lsblk -d | awk '{print "/dev/" $1}' | grep 'sd\|hd\|vd'`);
+  devices_list=(`lsblk -d | awk '{print "/dev/" $1}' | grep 'sd\|hd\|vd\|nvme'`);
   PS3="$prompt1"
   echo -e "Attached Devices:\n"
   lsblk -lnp -I 2,3,8,9,22,34,56,57,58,65,66,67,68,69,70,71,72,91,128,129,130,131,132,133,134,135 | awk '{print $1,$4,$6,$7}'| column -t


### PR DESCRIPTION
I have a new NUC with a samsung pro 950 m2 ssd ; it appears as /dev/nvme0n1 so I added a match to the devices_list calculation