### PR TITLE
Removing infinality

### DIFF
--- a/lilo
+++ b/lilo
@@ -634,34 +634,13 @@ install_xorg(){
 #}}}
 #FONT CONFIGURATION {{{
 font_config(){
-  while true
-  do
-    print_title "FONTS CONFIGURATION - https://wiki.archlinux.org/index.php/Font_Configuration"
-    print_info "Fontconfig is a library designed to provide a list of available fonts to applications, and also for configuration for how fonts get rendered."
-    echo " 1) Default"
-    echo " 2) Infinality"
-    echo ""
-    read_input $FONTCONFIG
-    case "$OPTION" in
-      1)
-        pacman -S --asdeps --needed cairo fontconfig freetype2
-        break
-        ;;
-      2)
-        print_title "INFINALITY - https://wiki.archlinux.org/index.php/Infinality-bundle%2Bfonts"
-        add_key "962DDE58"
-        add_repository "infinality-bundle" "http://bohoomil.com/repo/\$arch" "Never"
-        [[ $ARCHI == x86_64 ]] && add_repository "infinality-bundle-multilib" "http://bohoomil.com/repo/multilib/\$arch" "Never"
-        pacman -S --needed infinality-bundle
-        [[ $ARCHI == x86_64 ]] && pacman -S --needed infinality-bundle-multilib
-        break
-        ;;
-      *)
-        invalid_option
-        ;;
-    esac
-  done
-  pause_function
+  print_title "FONTS CONFIGURATION - https://wiki.archlinux.org/index.php/Font_Configuration"
+  print_info "Fontconfig is a library designed to provide a list of available fonts to applications, and also for configuration for how fonts get rendered."
+  read_input_text "Install Fontconfig" $FONTCONFIG
+  if [[ $OPTION == y ]]; then
+    pacman -S --asdeps --needed cairo fontconfig freetype2
+    pause_function
+  fi
 }
 #}}}
 #VIDEO CARDS {{{

--- a/lilo.automode
+++ b/lilo.automode
@@ -47,10 +47,7 @@
   ZSH="y"
   OH_MY_ZSH="y"
   PROPRIETARY_DRIVER="n" # Proprietary (NVIDIA) driver
-  #FONT CONFIGURATION {{{
-    # 1) Default
-    # 2) Infinality
-    FONTCONFIG=2
+  FONTCONFIG="y"
   #}}}
   #ADDITIONAL FIRMWARE {{{
     # 1) aic94xx-firmware


### PR DESCRIPTION
Quick fix to remove infinality as it is currently un-maintained and currently broken. (it breaks the rest of the install script as well)

The alternative is to use the Infinality AUR packages. But they are also not in a state that work out of the box, and require extra configuration that seems very hacky and patchy.