### PR TITLE
Fix for sshd_config

### DIFF
--- a/lilo
+++ b/lilo
@@ -484,7 +484,7 @@ install_ssh(){
       sed -i '/LogLevel/s/^#//' /etc/ssh/sshd_config
       sed -i '/LoginGraceTime/s/^#//' /etc/ssh/sshd_config
       sed -i '/PermitRootLogin/s/^#//' /etc/ssh/sshd_config
-      sed -i '/HostbasedAuthentication/s/^#//' /etc/ssh/sshd_config
+      sed -i '/HostbasedAuthentication no/s/^#//' /etc/ssh/sshd_config
       sed -i '/StrictModes/s/^#//' /etc/ssh/sshd_config
       sed -i '/RSAAuthentication/s/^#//' /etc/ssh/sshd_config
       sed -i '/PubkeyAuthentication/s/^#//' /etc/ssh/sshd_config


### PR DESCRIPTION
it was removing a # on "HostbasedAuthentication" and also on "HostbasedAuthentication no" causing a error on starting the ssh service.