### PR TITLE
Patched pacaur failing to install due to miss-configured GPG key.

### DIFF
--- a/lilo
+++ b/lilo
@@ -370,8 +370,8 @@ choose_aurhelper(){
         if ! is_package_installed "pacaur" ; then
           package_install "base-devel yajl expac"
           pacman -D --asdeps yajl expac
-          add_key "F56C0C53"
-          aui_download_packages "cower pacaur"
+          add_key_user "hkp://pgp.mit.edu 1EB2638FF56C0C53"
+	  aui_download_packages "cower pacaur"
           pacman -D --asdeps cower
           if ! is_package_installed "pacaur" ; then
             echo "Pacaur not installed. EXIT now"

--- a/sharedfuncs
+++ b/sharedfuncs
@@ -383,6 +383,11 @@
     pacman-key -r $1
     pacman-key --lsign-key $1
   } #}}}
+  add_key_user { #{{{
+  	su - ${username} -c"
+	gpg --recv-keys --keyserver $1
+	"
+  } #}}}
   pacman_key(){ #{{{
     if [[ ! -d /etc/pacman.d/gnupg ]]; then
       print_title "PACMAN KEY - https://wiki.archlinux.org/index.php/pacman-key"


### PR DESCRIPTION
Pacaur fails to build with your script due to the gpg key required by cower not being added as a non root user. The wrong key was also originally used. I have updated it the correct key and added a function of add_key_user to add the key as the user created at the begging of the script.

Some questions before I start working on some things.

If I were to write a monitoring section with some utilities such as [netdata, nload, htop, etc] would it be plausible to be accepted? (Would be in a new pull RQ)

Thanks.