### PR TITLE
Remove bad practice from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can try it first with a `virtualbox`
 ## How to get it
 ### With git
 - Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`
-- Get list of packages and install git: `pacman -Sy git`
+- Get list of packages and install git: `pacman -Syu git`
 - get the script: `git clone git://github.com/helmuthdu/aui`
 
 ### Without git


### PR DESCRIPTION
`pacman -Sy` should not be used according to the [Arch Wiki](https://wiki.archlinux.org/index.php/pacman#Installing_packages). Quote: In practice, do not run `pacman -Sy package_name` instead of `pacman -Syu package_name`, as this could lead to dependency issues.