### PR TITLE
Do not call pacman with -u to avoid upgrading the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can try it first with a `virtualbox`
 ## How to get it
 ### With git
 - Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`
-- Get list of packages and install git: `pacman -Syu git`
+- Get list of packages and install git: `pacman -Sy git`
 - get the script: `git clone git://github.com/helmuthdu/aui`
 
 ### Without git


### PR DESCRIPTION
When calling pacman with `-u` it performs a system upgrade and also install `git` but it could happen that the `linux-*` get upgraded also and then in the first step after partitioning the disk it fails because it can find `ext4` as a known file system.

So, I'm removing `-u` to DO NOT perform a system upgrade.