### PR TITLE
Fix timedatectl error: "Failed to create bus connection: No such file or directory"

### DIFF
--- a/fifo
+++ b/fifo
@@ -596,7 +596,7 @@ configure_timezone(){
   arch_chroot "sed -i '/#NTP=/d' /etc/systemd/timesyncd.conf"
   arch_chroot "sed -i 's/#Fallback//' /etc/systemd/timesyncd.conf"
   arch_chroot "echo \"FallbackNTP=0.pool.ntp.org 1.pool.ntp.org 0.fr.pool.ntp.org\" >> /etc/systemd/timesyncd.conf"
-  arch_chroot "timedatectl set-ntp true "
+  arch_chroot "systemctl enable systemd-timesyncd.service"
 }
 #}}}
 #CONFIGURE HARDWARECLOCK {{{


### PR DESCRIPTION
Applying solution from https://github.com/systemd/systemd/issues/798