### PR TITLE
Fix for wireless connection

### DIFF
--- a/sharedfuncs
+++ b/sharedfuncs
@@ -217,7 +217,6 @@
             break
             ;;
           3)
-            ip link set ${WIRELESS_DEV} up
             wifi-menu ${WIRELESS_DEV}
             break
             ;;


### PR DESCRIPTION
To be honest, I know nothing about this, but I have found the problematic line and I'm doing this so that someone who understands this better can properly fix it.

For some reason, the line **ip link set ${WIRELESS_DEV} up** prevents **wifi-menu** to work properly on my old laptop(don't know if this info is important or not, but I haven't tried this script anywhere else).
Without it, **wifi-menu** succeeds, but there is one more problem. Even if **wifi-menu** succeeds, the internet connection isn't instantly working, it needs a few seconds to work properly and without some additional delay the script will conclude that connection can't be established.

Here is some info that might help in fixing the first issue properly.

On initial boot, **ip link** showed:
3: wlp2s0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000

After **ip link set wlp2s0 up**, the **ip link** showed:
3: wlp2s0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000

[ At this point, **wifi-menu** couldn't succeed. ]

After **ip link set wlp2s0 down**  (or from the initial boot) and successful **wifi-menu**, the **ip link** showed:
3: wlp2s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
