### PR TITLE
Clarify lilo bashrc option descriptions

### DIFF
--- a/lilo
+++ b/lilo
@@ -178,7 +178,7 @@ select_user(){
   configure_user_account(){
     #BASHRC {{{
     print_title "BASHRC - https://wiki.archlinux.org/index.php/Bashrc"
-    bashrc_list=("Default" "Vanilla" "Get from github");
+    bashrc_list=("Get helmuthdu .bashrc from github" "Vanilla .bashrc" "Get personal .bashrc from github");
     PS3="$prompt1"
     echo -e "Choose your .bashrc\n"
     select OPT in "${bashrc_list[@]}"; do


### PR DESCRIPTION
Without looking at the source, it wasn't clear what the lilo bashrc options did. This PR adds more detailed descriptions to help the user choose the right option.