### PR TITLE
feature/installing: Added the option to choose from linux, linux-lts or linux-hardened before install

### DIFF
--- a/fifo
+++ b/fifo
@@ -509,11 +509,9 @@ select_linux_version() {
        if [ "linux (default)" == "$EDITOR" ];then
           pacstrap ${MOUNTPOINT} base linux-headers
        elif [ "linux-lts (long term support)" == "$EDITOR" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} -
-          pacstrap ${MOUNTPOINT} linux-lts-headers
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} - linux-lts-headers
        elif [ "linux-hardened (security features)" == "$EDITOR" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} -
-          pacstrap ${MOUNTPOINT} linux-hardened-headers
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} - linux-hardened-headers
       fi
       break
     else

--- a/fifo
+++ b/fifo
@@ -499,13 +499,36 @@ format_partitions(){
 }
 #}}}
 #INSTALL BASE SYSTEM {{{
+select_linux_version() {
+  print_title "LINUX VERSION"
+  version_list=("linux (default)" "linux-lts (long term support)" "linux-hardened (security features)");
+  PS3="$prompt1"
+  echo -e "Select linux version to install\n"
+  select VERSION in "${version_list[@]}"; do
+    if contains_element "$VERSION" "${version_list[@]}"; then
+       if [ "linux (default)" == "$EDITOR" ];then
+          pacstrap ${MOUNTPOINT} base linux-headers
+       elif [ "linux-lts (long term support)" == "$EDITOR" ];then
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} -
+          pacstrap ${MOUNTPOINT} linux-lts-headers
+       elif [ "linux-hardened (security features)" == "$EDITOR" ];then
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} -
+          pacstrap ${MOUNTPOINT} linux-hardened-headers
+      fi
+      break
+    else
+      invalid_option
+    fi
+  done
+}
 install_base_system(){
   print_title "INSTALL BASE SYSTEM"
   print_info "Installing PGP keyring"
   pacman -Sy archlinux-keyring
   print_info "Using the pacstrap script we install the base system. The base-devel package group will be installed also."
   rm ${MOUNTPOINT}${EFI_MOUNTPOINT}/vmlinuz-linux
-  pacstrap ${MOUNTPOINT} base base-devel parted btrfs-progs f2fs-tools ntp net-tools
+  select_linux_version
+  pacstrap ${MOUNTPOINT} base-devel parted btrfs-progs f2fs-tools ntp net-tools
   [[ $? -ne 0 ]] && error_msg "Installing base system to ${MOUNTPOINT} failed. Check error messages above."
   local PTABLE=`parted -l | grep "gpt"`
   [[ -n $PTABLE ]] && pacstrap ${MOUNTPOINT} gptfdisk

--- a/fifo
+++ b/fifo
@@ -506,11 +506,11 @@ select_linux_version() {
   echo -e "Select linux version to install\n"
   select VERSION in "${version_list[@]}"; do
     if contains_element "$VERSION" "${version_list[@]}"; then
-       if [ "linux (default)" == "$EDITOR" ];then
+       if [ "linux (default)" == "$VERSION" ];then
           pacstrap ${MOUNTPOINT} base linux-headers
-       elif [ "linux-lts (long term support)" == "$EDITOR" ];then
+       elif [ "linux-lts (long term support)" == "$VERSION" ];then
           pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} - linux-lts-headers
-       elif [ "linux-hardened (security features)" == "$EDITOR" ];then
+       elif [ "linux-hardened (security features)" == "$VERSION" ];then
           pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} - linux-hardened-headers
       fi
       break

--- a/fifo
+++ b/fifo
@@ -509,10 +509,10 @@ select_linux_version() {
        if [ "linux (default)" == "$EDITOR" ];then
           pacstrap ${MOUNTPOINT} base linux-headers
        elif [ "linux-lts (long term support)" == "$EDITOR" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} -
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} -
           pacstrap ${MOUNTPOINT} linux-lts-headers
        elif [ "linux-hardened (security features)" == "$EDITOR" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} -
+          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} -
           pacstrap ${MOUNTPOINT} linux-hardened-headers
       fi
       break


### PR DESCRIPTION
I had to install quite a few arch linux machines with your install script and I wanted them to run with the hardened linux kernel. So I had a problem: I had to install arch, then remove the linux kernel, install linux-hardened and update the bootloader.

So it came in my mind that it would be way easier and quicker if your install sciript would provide a selctor for the linux version I want to install.

After this idea, I forked your repo and extended it with this feature. I made sure that the installer doesn't have to install and remove the old linux kernel before installing the hardened kernel, so I bypassed this with an regex expression.

The menu for selecting looks like this:
![Linux version select menu](https://user-images.githubusercontent.com/31348196/34545517-c6dc3af0-f0ed-11e7-9f7f-8673df705805.png)
Maybe you can make it prettier or add an "Are you really sure with 'linux-hardened'?" question.

In addition I added the linux-lts package to choose from.

I also made some tests and it worked for all versions.

Here is a screenshot of a fresh installed arch with linux-hardened installed with the forked script:
![Arch screenshot](https://user-images.githubusercontent.com/31348196/34545583-3fdefdac-f0ee-11e7-8019-a5bde377c848.png)

I think this would also be very useful for other users, so I created this pull request.
If you have any questions, just ask me.

