### PR TITLE
Fixed mkinitcpio and driver installation with custom kernel

### DIFF
--- a/fifo
+++ b/fifo
@@ -659,7 +659,13 @@ configure_mkinitcpio(){
   print_info "mkinitcpio is a Bash script used to create an initial ramdisk environment."
   [[ $LUKS -eq 1 ]] && sed -i '/^HOOK/s/block/block keymap encrypt/' ${MOUNTPOINT}/etc/mkinitcpio.conf
   [[ $LVM -eq 1 ]] && sed -i '/^HOOK/s/filesystems/lvm2 filesystems/' ${MOUNTPOINT}/etc/mkinitcpio.conf
-  arch_chroot "mkinitcpio -p linux"
+  if [ "$(arch-chroot ${MOUNTPOINT} ls /boot | grep hardened -c)" -gt "0" ]; then
+    arch_chroot "mkinitcpio -p linux-hardened"
+  elif [ "$(arch-chroot ${MOUNTPOINT} ls /boot | grep lts -c)" -gt "0" ]; then
+    arch_chroot "mkinitcpio -p linux-lts"
+  else
+    arch_chroot "mkinitcpio -p linux"
+  fi
 }
 #}}}
 #INSTALL BOOTLOADER {{{

--- a/lilo
+++ b/lilo
@@ -651,7 +651,11 @@ install_video_cards(){
   check_vga
   #Virtualbox {{{
   if [[ ${VIDEO_DRIVER} == virtualbox ]]; then
-    package_install "virtualbox-guest-modules-arch virtualbox-guest-utils mesa-libgl"
+    if [ "$(ls /boot | grep hardened -c)" -gt "0" ] || [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
+      package_install "virtualbox-guest-dkms virtualbox-guest-utils mesa-libgl"
+    else
+      package_install "virtualbox-guest-modules-arch virtualbox-guest-utils mesa-libgl"
+    fi
     add_module "vboxguest vboxsf vboxvideo" "virtualbox-guest"
     add_user_to_group ${username} vboxsf
     system_ctl disable ntpd

--- a/lilo
+++ b/lilo
@@ -673,10 +673,16 @@ install_video_cards(){
   #}}}
   #VMware {{{
   elif [[ ${VIDEO_DRIVER} == vmware ]]; then
-    package_install "xf86-video-vmware xf86-input-vmmouse open-vm-tools"
+    package_install "xf86-video-vmware xf86-input-vmmouse"
+    if [ "$(ls /boot | grep hardened -c)" -gt "0" ] || [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
+      aur_package_install "open-vm-tools-dkms"
+    else
+      package_install "open-vm-tools"
+    fi
     cat /proc/version > /etc/arch-release
     system_ctl disable ntpd
     system_ctl enable vmtoolsd
+    create_ramdisk_environment
   #}}}
   #Bumblebee {{{
   elif [[ ${VIDEO_DRIVER} == bumblebee ]]; then

--- a/lilo
+++ b/lilo
@@ -693,7 +693,11 @@ install_video_cards(){
   elif [[ ${VIDEO_DRIVER} == nvidia ]]; then
     XF86_DRIVERS=$(pacman -Qe | grep xf86-video | awk '{print $1}')
     [[ -n $XF86_DRIVERS ]] && pacman -Rcsn $XF86_DRIVERS
-    pacman -S --needed nvidia{,-utils}
+    if [ "$(ls /boot | grep hardened -c)" -gt "0" ] || [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
+      package_install "nvidia-dkms nvidia-utils libglvnd"
+    else
+      package_install "nvidia nvidia-utils libglvnd"
+    fi
     [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-nvidia-utils
     replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
     replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf

--- a/lilo
+++ b/lilo
@@ -726,8 +726,13 @@ install_video_cards(){
     [[ -f /etc/X11/xorg.conf.d/20-radeon.conf ]] && rm /etc/X11/xorg.conf.d/20-radeon.conf
     [[ -f /etc/modules-load.d/catalyst.conf ]] && rm /etc/modules-load.d/catalyst.conf
     [[ -f /etc/X11/xorg.conf ]] && rm /etc/X11/xorg.conf
-    package_install "xf86-video-${VIDEO_DRIVER} mesa-libgl mesa-vdpau libvdpau-va-gl"
-    add_module "radeon" "ati"
+    if [ "$(ls /boot | grep hardened -c)" -gt "0" ] || [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
+      aur_package_install "catalyst-total"
+     else
+       package_install "xf86-video-${VIDEO_DRIVER} mesa-libgl mesa-vdpau libvdpau-va-gl"
+      add_module "radeon" "ati"
+    fi
+    create_ramdisk_environment
   #}}}
   #Intel {{{
   elif [[ ${VIDEO_DRIVER} == intel ]]; then

--- a/lilo
+++ b/lilo
@@ -701,6 +701,7 @@ install_video_cards(){
     [[ -n $XF86_DRIVERS ]] && pacman -Rcsn $XF86_DRIVERS
     if [ "$(ls /boot | grep hardened -c)" -gt "0" ] || [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
       package_install "nvidia-dkms nvidia-utils libglvnd"
+      echo "Do not forget to make a mkinitcpio every time you updated the nvidia driver!"
     else
       package_install "nvidia nvidia-utils libglvnd"
     fi
@@ -839,6 +840,7 @@ install_additional_firmwares(){
         esac
       done
       source sharedfuncs_elihw
+      create_ramdisk_environment
     done
   fi
 }

--- a/lilo
+++ b/lilo
@@ -645,6 +645,15 @@ font_config(){
 }
 #}}}
 #VIDEO CARDS {{{
+create_ramdisk_environment(){
+  if [ "$(ls /boot | grep hardened -c)" -gt "0" ]; then
+    mkinitcpio -p linux-hardened
+  elif [ "$(ls /boot | grep lts -c)" -gt "0" ]; then
+    mkinitcpio -p linux-lts
+  else
+    mkinitcpio -p linux
+  fi
+}
 install_video_cards(){
   package_install "dmidecode"
   print_title "VIDEO CARD"
@@ -660,6 +669,7 @@ install_video_cards(){
     add_user_to_group ${username} vboxsf
     system_ctl disable ntpd
     system_ctl enable vboxservice
+    create_ramdisk_environment
   #}}}
   #VMware {{{
   elif [[ ${VIDEO_DRIVER} == vmware ]]; then
@@ -676,7 +686,7 @@ install_video_cards(){
     [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-virtualgl lib32-nvidia-utils
     replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
     replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf
-    mkinitcpio -p linux
+    create_ramdisk_environment
     add_user_to_group ${username} bumblebee
   #}}}
   #NVIDIA {{{
@@ -687,7 +697,7 @@ install_video_cards(){
     [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-nvidia-utils
     replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
     replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf
-    mkinitcpio -p linux
+    create_ramdisk_environment
     nvidia-xconfig --add-argb-glx-visuals --allow-glx-with-composite --composite -no-logo --render-accel -o /etc/X11/xorg.conf.d/20-nvidia.conf;
   #}}}
   #Nouveau [NVIDIA] {{{
@@ -698,7 +708,7 @@ install_video_cards(){
     package_install "xf86-video-${VIDEO_DRIVER} mesa-libgl libvdpau-va-gl"
     replace_line '#*options nouveau modeset=1' 'options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
     replace_line '#*MODULES="nouveau"' 'MODULES="nouveau"' /etc/mkinitcpio.conf
-    mkinitcpio -p linux
+    create_ramdisk_environment
   #}}}
   #ATI {{{
   elif [[ ${VIDEO_DRIVER} == ati ]]; then


### PR DESCRIPTION
Hi again,
I found out that the mkinitcpio command only creates the ramdisk for the default kernel. So I added a few lines to check the kernel version and create the right one for all specific kernel versions. [fifo]

Additionally, I found out that many drivers (such as virtualbox, nvidia, ...) need other packages (often [drivername]-dkms) to run without problems on custom kernels. 
Here is the Nvidia archlinux page for custom kernels if you need more information: [Nvidia Custom Kernel](https://wiki.archlinux.org/index.php/NVIDIA#Custom_kernel)

So I also checked if the system runs on a custom kernel (lts or hardened) and installed the needed packages. [lilo]

I tested it with virtualbox and the script detected my custom kernel (hardened in my case) and installed the right dkms packages:
![grafik](https://user-images.githubusercontent.com/31348196/34745386-a3058616-f590-11e7-9da8-4e750afa6bcc.png)

Oh and the changes with the mkinitcpio also work fine:
![grafik](https://user-images.githubusercontent.com/31348196/34745511-1777ec1e-f591-11e7-8155-8e0fdcb1301b.png)

I installed gnome via the script and it worked without any flaws. For example I could resize the window and the resolution of archlinux also changes and so on.

The only thing I didn't change was the bumblebee drivers, because I am not sure if it works well with custom kernel. Maybe you will get another pull request from me in the future :)

Finally, I can say that fixed every problem I could find.
If you have any questions, feel free to ask.