### PR TITLE
Fix and update android-udev support

### DIFF
--- a/lilo
+++ b/lilo
@@ -826,7 +826,7 @@ install_additional_firmwares(){
             ;;
           11)
             package_install "libmtp"
-            aur_package_install "android-udev"
+            package_install "android-udev"
             ;;
           12)
             package_install "libraw1394"


### PR DESCRIPTION
The old AUR version of this package no longer exists. The latest version of this package with support for the most recent Linux kernel version has been added to the official community repository.