### PR TITLE
Update speedtest-cli support

### DIFF
--- a/lilo
+++ b/lilo
@@ -1007,7 +1007,7 @@ install_desktop_environment(){
       echo "10) $(menu_item "xfburn")"
       echo "11) $(menu_item "xcompmgr")"
       echo "12) $(menu_item "zathura")"
-      echo "13) $(menu_item "speedtest-cli") $AUR"
+      echo "13) $(menu_item "speedtest-cli")"
       echo ""
       echo " d) DONE"
       echo ""
@@ -1053,7 +1053,7 @@ install_desktop_environment(){
             package_install "zathura"
             ;;
           13)
-            aur_package_install "speedtest-cli"
+            package_install "speedtest-cli"
             ;;
           "d")
             break


### PR DESCRIPTION
The AUR version of this package no longer exists. The latest version of this package has been added to the official community repository.
Official: https://www.archlinux.org/packages/community/any/speedtest-cli/