### PR TITLE
Update nautilus-share support

### DIFF
--- a/lilo
+++ b/lilo
@@ -1131,7 +1131,7 @@ install_desktop_environment(){
       print_info "GNOME is a desktop environment and graphical user interface that runs on top of a computer operating system. It is composed entirely of free and open source software. It is an international project that includes creating software development frameworks, selecting application software for the desktop, and working on the programs that manage application launching, file handling, and window and task management."
       package_install "gnome gnome-extra gnome-software gnome-initial-setup"
       package_install "deja-dup gedit-plugins gpaste gnome-tweak-tool gnome-power-manager"
-      aur_package_install "nautilus-share"
+      package_install "nautilus-share"
       # remove gnome games
       package_remove "aisleriot atomix four-in-a-row five-or-more gnome-2048 gnome-chess gnome-klotski gnome-mahjongg gnome-mines gnome-nibbles gnome-robots gnome-sudoku gnome-tetravex gnome-taquin swell-foop hitori iagno quadrapassel lightsoff tali"
       # config xinitrc
@@ -1254,7 +1254,7 @@ install_desktop_environment(){
       package_install "gnome gnome-extra gnome-software gnome-initial-setup telepathy"
       package_install "deja-dup gedit-plugins gpaste gnome-tweak-tool gnome-power-manager"
       package_install "budgie-desktop"
-      aur_package_install "nautilus-share"
+      package_install "nautilus-share"
       # remove gnome games
       package_remove "aisleriot atomix four-in-a-row five-or-more gnome-2048 gnome-chess gnome-klotski gnome-mahjongg gnome-mines gnome-nibbles gnome-robots gnome-sudoku gnome-tetravex gnome-taquin swell-foop hitori iagno quadrapassel lightsoff"
       # config xinitrc


### PR DESCRIPTION
The AUR version of this package no longer exists. The latest version of this package has been added to the official community repository.
Official: https://www.archlinux.org/packages/community/x86_64/nautilus-share/