### PR TITLE
Remove wicd-kde support

### DIFF
--- a/lilo
+++ b/lilo
@@ -1411,7 +1411,8 @@ install_nm_wicd(){
       print_title "WICD - https://wiki.archlinux.org/index.php/Wicd"
       print_info "Wicd is a network connection manager that can manage wireless and wired interfaces, similar and an alternative to NetworkManager."
       if [[ ${KDE} -eq 1 ]]; then
-        aur_package_install "wicd wicd-kde"
+        echo "KDE unsupported. Installing CLI and curses versions only."
+        package_install "wicd"
       else
         package_install "wicd wicd-gtk"
       fi


### PR DESCRIPTION
The AUR version of this package no longer exists. There is no KDE GUI available for wicd at this time.
Wiki: https://wiki.archlinux.org/index.php/wicd#KDE_client