### PR TITLE
kdeutils-sweeper has been replaced by sweeper

### DIFF
--- a/lilo
+++ b/lilo
@@ -1149,7 +1149,7 @@ install_desktop_environment(){
       print_title "KDE - https://wiki.archlinux.org/index.php/KDE"
       print_info "KDE is an international free software community producing an integrated set of cross-platform applications designed to run on Linux, FreeBSD, Microsoft Windows, Solaris and Mac OS X systems. It is known for its Plasma Desktop, a desktop environment provided as the default working environment on many Linux distributions."
       package_install "plasma kf5 sddm"
-      package_install "ark dolphin dolphin-plugins kio-extras kdeconnect quota-tools gwenview kipi-plugins kate kcalc konsole spectacle okular kdeutils-sweeper kwalletmanager"
+      package_install "ark dolphin dolphin-plugins kio-extras kdeconnect quota-tools gwenview kipi-plugins kate kcalc konsole spectacle okular sweeper kwalletmanager"
       is_package_installed "cups" && package_install "print-manager"
       [[ $LOCALE != en_US ]] && package_install "kde-l10n-$LOCALE_KDE"
       # config xinitrc


### PR DESCRIPTION
source: https://www.archlinux.org/packages/extra/x86_64/sweeper/