### PR TITLE
foomatic-filters no longer exists in the arch packages

### DIFF
--- a/lilo
+++ b/lilo
@@ -761,7 +761,7 @@ install_cups(){
   read_input_text "Install CUPS (aka Common Unix Printing System)" $CUPS
   if [[ $OPTION == y ]]; then
     package_install "cups cups-filters ghostscript gsfonts"
-    package_install "gutenprint foomatic-db foomatic-db-engine foomatic-db-nonfree foomatic-filters foomatic-db-ppds foomatic-db-nonfree-ppds hplip splix cups-pdf foomatic-db-gutenprint-ppds"
+    package_install "gutenprint foomatic-db foomatic-db-engine foomatic-db-nonfree foomatic-db-ppds foomatic-db-nonfree-ppds hplip splix cups-pdf foomatic-db-gutenprint-ppds"
     system_ctl enable org.cups.cupsd.service
     pause_function
   fi


### PR DESCRIPTION
foomatic-filters no longer exists in the arch packages resulting in target not found when installing CUPS.