### PR TITLE
Add partition resize entry for script install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can try it first with a `virtualbox`
 - get the script: `git clone git://github.com/helmuthdu/aui`
 
 ### Without git
+- Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`
 - get the script: ` wget https://github.com/helmuthdu/aui/tarball/master -O - | tar xz`
     - an alternate URL (for less typing (github shorten)) is ` wget https://git.io/vS1GH -O - | tar xz`
     - an alternate URL (for less typing) is ` wget http://bit.ly/NoUPC6 -O - | tar xz`


### PR DESCRIPTION
If you install the script for the first time without git, you can miss the "Increase cowspace partition" list item for the instructions with git (which I did). Mirroring that entry could help first-time users in the future.