### PR TITLE
fix bad entry when generate locale

### DIFF
--- a/fifo
+++ b/fifo
@@ -609,7 +609,7 @@ configure_locale(){
     read_input_text "Confirm locale ($LOCALE)"
   done
   echo 'LANG="'$LOCALE_UTF8'"' > ${MOUNTPOINT}/etc/locale.conf
-  arch_chroot "sed -i 's/#'${LOCALE_UTF8}'/'${LOCALE_UTF8}'/' /etc/locale.gen"
+  arch_chroot "sed -i 's/#\('${LOCALE_UTF8}'\)/\1/' /etc/locale.gen"
   arch_chroot "locale-gen"
 }
 #}}}


### PR DESCRIPTION
When uncommenting locale in /etc/locale.gen. it will also replace empty space with a dot due to regex dot will match any character. For example option 285 (vn_VN)
```
#vi_VN UTF-8
```
will be changed to
```
vi_VN.UTF-8
```