### PR TITLE
[fifo] fix missing pacman-contrib needed for rankmirrors

### DIFF
--- a/fifo
+++ b/fifo
@@ -101,6 +101,7 @@ configure_mirrorlist(){
     echo " Unable to update, could not download list."
   fi
   # better repo should go first
+  pacman -Sy pacman-contrib
   cp /etc/pacman.d/mirrorlist /etc/pacman.d/mirrorlist.tmp
   rankmirrors /etc/pacman.d/mirrorlist.tmp > /etc/pacman.d/mirrorlist
   rm /etc/pacman.d/mirrorlist.tmp


### PR DESCRIPTION
rankmirrors was moved to pacman-contrib. needs to be installed before being run otherwise mirrorlist ends up blank. Solves #390 