### PR TITLE
Fix samba package no longer contains a smb.conf.default

### DIFF
--- a/lilo
+++ b/lilo
@@ -540,7 +540,7 @@ install_samba(){
   read_input_text "Install Samba" $SAMBA
   if [[ $OPTION == y ]]; then
     package_install "samba smbnetfs"
-    [[ ! -f /etc/samba/smb.conf ]] && cp /etc/samba/smb.conf.default /etc/samba/smb.conf
+    [[ ! -f /etc/samba/smb.conf ]] && wget -O /etc/samba/smb.conf "https://git.samba.org/samba.git/?p=samba.git;a=blob_plain;f=examples/smb.conf.default;hb=HEAD"
     local CONFIG_SAMBA=`cat /etc/samba/smb.conf | grep usershare`
     if [[ -z $CONFIG_SAMBA ]]; then
       # configure usershare

--- a/lilo
+++ b/lilo
@@ -540,7 +540,7 @@ install_samba(){
   read_input_text "Install Samba" $SAMBA
   if [[ $OPTION == y ]]; then
     package_install "samba smbnetfs"
-    [[ ! -f /etc/samba/smb.conf ]] && wget -O /etc/samba/smb.conf "https://git.samba.org/samba.git/?p=samba.git;a=blob_plain;f=examples/smb.conf.default;hb=HEAD"
+    [[ ! -f /etc/samba/smb.conf ]] && wget -q -O /etc/samba/smb.conf "https://git.samba.org/samba.git/?p=samba.git;a=blob_plain;f=examples/smb.conf.default;hb=HEAD"
     local CONFIG_SAMBA=`cat /etc/samba/smb.conf | grep usershare`
     if [[ -z $CONFIG_SAMBA ]]; then
       # configure usershare


### PR DESCRIPTION
Since it was removed from the package we should get it directly from samba git repo.

Source: [Samba - ArchWiki](https://wiki.archlinux.org/index.php/samba#Installation)
[smb.conf.default](https://git.samba.org/samba.git/?p=samba.git;a=blob_plain;f=examples/smb.conf.default;hb=HEAD)