### PR TITLE
Fix error while installing "samba" because missing "wget" command

### DIFF
--- a/lilo
+++ b/lilo
@@ -539,7 +539,7 @@ install_samba(){
   print_info "Samba is a re-implementation of the SMB/CIFS networking protocol, it facilitates file and printer sharing among Linux and Windows systems as an alternative to NFS."
   read_input_text "Install Samba" $SAMBA
   if [[ $OPTION == y ]]; then
-    package_install "samba smbnetfs"
+    package_install "wget samba smbnetfs"
     [[ ! -f /etc/samba/smb.conf ]] && wget -q -O /etc/samba/smb.conf "https://git.samba.org/samba.git/?p=samba.git;a=blob_plain;f=examples/smb.conf.default;hb=HEAD"
     local CONFIG_SAMBA=`cat /etc/samba/smb.conf | grep usershare`
     if [[ -z $CONFIG_SAMBA ]]; then


### PR DESCRIPTION
Hi @helmuthdu, love your script! 😃 

While trying to install `samba` in the `lilo`, an error occured and then the script was stuck in an infinite loop:

```bash
./lilo: line 543: wget: command not found
cat: /etc/samba/smb.conf: No such file or directory
groupadd: group 'sambashare' already exists
sed: can't read /etc/samba/smb.conf: No such file or directory
sed: can't read /etc/samba/smb.conf: No such file or directory
Enter your new samba account password:
Can't load /etc/samba/smb.conf - run testparam to debug it
Can't load /etc/samba/smb.conf - run testparam to debug it
Can't load /etc/samba/smb.conf - run testparam to debug it
Can't load /etc/samba/smb.conf - run testparam to debug it
Can't load /etc/samba/smb.conf - run testparam to debug it
...
```

So I simply added `wget` to the list of package required before `samba` installation.  👍 