### PR TITLE
Remove illegal mkfs option for btrfs

### DIFF
--- a/fifo
+++ b/fifo
@@ -318,8 +318,7 @@ format_partitions(){
       mkfs.${filesystem} $1 \
         $([[ ${filesystem} == xfs || ${filesystem} == btrfs || ${filesystem} == reiserfs ]] && echo "-f") \
         $([[ ${filesystem} == vfat ]] && echo "-F32") \
-        $([[ $TRIM -eq 1 && ${filesystem} == ext4 ]] && echo "-E discard") \
-        $([[ $TRIM -eq 1 && ${filesystem} == btrfs ]] && echo "-O discard")
+        $([[ $TRIM -eq 1 && ${filesystem} == ext4 ]] && echo "-E discard")
       fsck $1
       mkdir -p $2
       mount -t ${filesystem} $1 $2


### PR DESCRIPTION
Filesystem btrfs has no mkfs option called "discard" - and makes the mkfs.btrfs command fail
Option "discard" mount-time option for btrfs

See: mkfs.btrfs btrfs(5)

man 5 btrfs
man 8 mkfs.btrfs