### PR TITLE
Fixes hang when using an USB stick with the UDF filesystem

### DIFF
--- a/fifo
+++ b/fifo
@@ -488,7 +488,7 @@ install_base_system(){
   select_linux_version
   pacstrap ${MOUNTPOINT} base-devel parted btrfs-progs f2fs-tools net-tools
   [[ $? -ne 0 ]] && error_msg "Installing base system to ${MOUNTPOINT} failed. Check error messages above."
-  local PTABLE=`parted -l | grep "gpt"`
+  local PTABLE=`parted -sl | grep "gpt"`
   [[ -n $PTABLE ]] && pacstrap ${MOUNTPOINT} gptfdisk
   WIRELESS_DEV=`ip link | grep wl | awk '{print $2}'| sed 's/://' | sed '1!d'`
   if [[ -n $WIRELESS_DEV ]]; then


### PR DESCRIPTION
When using "parted -l", parted asks for user interaction on errors, which is impossible while using this script.
by adding the "-s" option, we notify parted we are invoking it in a script, so no user interaction is required.