### PR TITLE
Add missing base packages to fix the installation

### DIFF
--- a/fifo
+++ b/fifo
@@ -467,7 +467,7 @@ select_linux_version() {
   select VERSION in "${version_list[@]}"; do
     if contains_element "$VERSION" "${version_list[@]}"; then
        if [ "linux (default)" == "$VERSION" ];then
-          pacstrap ${MOUNTPOINT} base linux-headers
+          pacstrap ${MOUNTPOINT} base linux linux-headers
        elif [ "linux-lts (long term support)" == "$VERSION" ];then
           pacstrap ${MOUNTPOINT} base linux-lts linux-lts-headers
        elif [ "linux-hardened (security features)" == "$VERSION" ];then

--- a/fifo
+++ b/fifo
@@ -469,10 +469,14 @@ select_linux_version() {
        if [ "linux (default)" == "$VERSION" ];then
           pacstrap ${MOUNTPOINT} base linux-headers
        elif [ "linux-lts (long term support)" == "$VERSION" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-lts/g | pacstrap ${MOUNTPOINT} - linux-lts-headers
+          pacstrap ${MOUNTPOINT} base linux-lts linux-lts-headers
        elif [ "linux-hardened (security features)" == "$VERSION" ];then
-          pacman -Sg base | cut -d ' ' -f 2 | sed s/\^linux\$/linux-hardened/g | pacstrap ${MOUNTPOINT} - linux-hardened-headers
+          pacstrap ${MOUNTPOINT} base linux-hardened linux-hardened-headers
       fi
+      pacstrap ${MOUNTPOINT} \
+        cryptsetup device-mapper dhcpcd diffutils e2fsprogs inetutils jfsutils \
+        less linux-firmware logrotate lvm2 man-db man-pages mdadm nano netctl \
+        perl reiserfsprogs s-nail sysfsutils texinfo usbutils vi which xfsprogs
       break
     else
       invalid_option


### PR DESCRIPTION
[The `base` group was replaced with the `base` package](https://www.archlinux.org/news/base-group-replaced-by-mandatory-base-package-manual-intervention-required/) and some packages are missing.

Without these essential packages like `linux` or `dhcpcd`, the installed system won't boot or can not connect to the internet.

I added these packages from [the list on ArchWiki](https://wiki.archlinux.org/index.php/Talk:Installation_guide#Changes_for_the_base_package):
> All packages that are in `base` (group), but not in `base` (package): 
> ```
> cryptsetup
> device-mapper
> dhcpcd
> diffutils
> e2fsprogs
> inetutils
> jfsutils
> less
> linux
> linux-firmware
> logrotate
> lvm2
> man-db
> man-pages
>mdadm
> nano
> netctl
> perl
> reiserfsprogs
>s-nail
> sysfsutils
> texinfo
> usbutils
> vi
> which
> xfsprogs
> ```

I'm not sure if all these packages are necessary or not but just make sure that installation script works like before.
