### PR TITLE
fix icons themes in automode

### DIFF
--- a/lilo.automode
+++ b/lilo.automode
@@ -119,9 +119,10 @@
   # 2) GTK2|GTK3 Themes
   THEMES_OPTIONS="1 2"
   #ICONS THEMES {{{
-    # 1) Numix
-    # 2) Papirus
-    ICONS_THEMES="2"
+    # 1) Arc
+    # 2) Numix
+    # 3) Papirus
+    ICONS_THEMES="3"
   #}}}
   #GTK THEMES {{{
     # 1) Arc


### PR DESCRIPTION
#418 added the arc icons theme, but the automode wasn't updated accordingly. 

this PR fixes the automode to install Papirus by default, which was the default icons theme before the change.