### PR TITLE
Add fallback icon theme for arc-icon-theme

### DIFF
--- a/lilo
+++ b/lilo
@@ -904,7 +904,7 @@ install_desktop_environment(){
       for OPT in ${OPTIONS[@]}; do
         case "$OPT" in
           1)
-            package_install "arc-icon-theme"
+            package_install "arc-icon-theme elementary-icon-theme"
             ;;
           2)
             aur_package_install "numix-icon-theme-git numix-circle-icon-theme-git"


### PR DESCRIPTION
[**arc-icon-theme**](https://www.archlinux.org/packages/community/any/arc-icon-theme/) uses [elementary-icon-theme](https://www.archlinux.org/packages/community/any/elementary-icon-theme/) as the secondary icon theme fallback. It's better to install these icon theme together.