### PR TITLE
Fix "swapon: swapfile has holes" error in Linux kernel 5.7

### DIFF
--- a/fifo
+++ b/fifo
@@ -369,7 +369,7 @@ format_partitions() {
         ;;
       2)
         total_memory=$(grep MemTotal /proc/meminfo | awk '{print $2/1024}' | sed 's/\..*//')
-        fallocate -l "${total_memory}"M "${MOUNTPOINT}"/swapfile
+        dd if=/dev/zero of="${MOUNTPOINT}"/swapfile bs=1M count="${total_memory}" status=progress
         chmod 600 "${MOUNTPOINT}"/swapfile
         mkswap "${MOUNTPOINT}"/swapfile
         swapon "${MOUNTPOINT}"/swapfile


### PR DESCRIPTION
When creating a swap file, dynamic space allocation such as using `fallocate` is not supported now.

`swapon(8)` says:
> The swap file implementation in the kernel expects to be able to write to the file directly, without the assistance of the filesystem. This is a problem on files with holes or on copy-on-write files on filesystems like Btrfs.
>
> Commands like cp(1) or truncate(1) create files with holes. These files will be rejected by swapon.
>
> Preallocated files created by fallocate(1) may be interpreted as files with holes too depending of the filesystem. Preallocated swap files are supported on XFS since Linux 4.18.
>
> The most portable solution to create a swap file is to use dd(1) and /dev/zero.

This PR changes the way to create swap file from `fallocate` to `dd`.

References:
- https://jlk.fjfi.cvut.cz/arch/manpages/man/swapon.8#Files_with_holes
- https://wiki.archlinux.org/index.php/Swap#Manually
- https://bugs.archlinux.org/task/66921