### PR TITLE
Fix option number splitting

### DIFF
--- a/sharedfuncs
+++ b/sharedfuncs
@@ -324,7 +324,7 @@ Run this script after your first boot with archlinux (as root)
     else
       printf "%s" "$prompt2"
       read -r OPTION
-      array=("$OPTION")
+      IFS=' ' read -r -a array <<< "${OPTION}"
     fi
     for line in "${array[@]/,/ }"; do
       if [[ ${line/-/} != "$line" ]]; then


### PR DESCRIPTION
I found that after making this script pass ShellCheck, the space-separated option is not work correctly because of the quoted variable. For example, if the user enters `1 2 3`, the script will read the input as a single string `1 2 3` and throw `invalid_option`, instead of split it into `1`, `2` and `3`.

This PR fixes that and also makes it still pass ShellCheck.