### PR TITLE
feat: add support for upd72020x-fw

### DIFF
--- a/lilo
+++ b/lilo
@@ -900,6 +900,7 @@ install_additional_firmwares(){
       echo "10) $(menu_item "libmtp") [Android Devices]"
       echo "11) $(menu_item "libraw1394") [IEEE1394 Driver]"
       echo "12) $(menu_item "wd719x-firmware") $AUR"
+      echo "13) $(menu_item "upd72020x-fw") $AUR"
       echo ""
       echo " d) DONE"
       echo ""
@@ -943,6 +944,9 @@ install_additional_firmwares(){
             ;;
           12)
             aur_package_install "wd719x-firmware"
+            ;;
+          13)
+            aur_package_install "upd72020x-fw"
             ;;
           "d")
             break


### PR DESCRIPTION
This will install Renesas uPD720201 / uPD720202 USB 3.0 chipsets
firmware and resolves the xhci_pci missing firmware warning for
mkinitcpio.