### PR TITLE
feat: add support for nvidia prime render offload

### DIFF
--- a/lilo
+++ b/lilo
@@ -797,16 +797,26 @@ install_video_cards(){
     system_ctl enable vmtoolsd
     create_ramdisk_environment
   #}}}
-  #Bumblebee {{{
-  elif [[ ${VIDEO_DRIVER} == bumblebee ]]; then
+  #Optimus {{{
+  elif [[ ${VIDEO_DRIVER} == optimus ]]; then
     XF86_DRIVERS=$(pacman -Qe | grep xf86-video | awk '{print $1}')
     [[ -n $XF86_DRIVERS ]] && pacman -Rcsn "$XF86_DRIVERS"
-    pacman -S --needed xf86-video-intel bumblebee nvidia
-    [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-virtualgl lib32-nvidia-utils
-    replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
-    replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf
-    create_ramdisk_environment
-    add_user_to_group "${username}" bumblebee
+    read_input_text "Use Bumblebee instead of NVIDIA PRIME Render Offload?" "$BUMBLEBEE"
+    if [[ $OPTION == y ]]; then
+      pacman -S --needed xf86-video-intel bumblebee nvidia
+      [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-virtualgl lib32-nvidia-utils
+      replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
+      replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf
+      create_ramdisk_environment
+      add_user_to_group "${username}" bumblebee
+    else
+      package_install "nvidia nvidia-utils libglvnd nvidia-prime"
+      package_install "mesa mesa-libgl libvdpau-va-gl"
+      [[ ${ARCHI} == x86_64 ]] && pacman -S --needed lib32-virtualgl lib32-nvidia-utils
+      replace_line '*options nouveau modeset=1' '#options nouveau modeset=1' /etc/modprobe.d/modprobe.conf
+      replace_line '*MODULES="nouveau"' '#MODULES="nouveau"' /etc/mkinitcpio.conf
+      create_ramdisk_environment
+    fi
   #}}}
   #NVIDIA {{{
   elif [[ ${VIDEO_DRIVER} == nvidia ]]; then

--- a/sharedfuncs
+++ b/sharedfuncs
@@ -266,8 +266,8 @@ Run this script after your first boot with archlinux (as root)
       cecho VMware
       VIDEO_DRIVER="vmware"
     elif [[ $_vga_length -eq 2 ]] && [[ -n $(echo "${_vga}" | grep "nvidia") || -f /sys/kernel/debug/dri/0/vbios.rom ]]; then
-      cecho Bumblebee
-      VIDEO_DRIVER="bumblebee"
+      cecho Optimus
+      VIDEO_DRIVER="optimus"
     elif [[ -n $(echo "${_vga}" | grep "nvidia") || -f /sys/kernel/debug/dri/0/vbios.rom ]]; then
       cecho Nvidia
       read_input_text "Install NVIDIA proprietary driver" "$BETTER_VIDEO_DRIVER"


### PR DESCRIPTION
This will allow the user to choose between bumblebee and the new PRIME
Render Offload method which is directly supported by NVIDIA.

NVIDIA PRIME Render Offload is set to be the default.