### PR TITLE
fix: cryptsetup open without TRIM

### DIFF
--- a/fifo
+++ b/fifo
@@ -206,7 +206,11 @@ setup_luks() {
   select OPT in "${block_list[@]}"; do
     if contains_element "$OPT" "${block_list[@]}"; then
       cryptsetup --cipher aes-xts-plain64 --key-size 512 --hash sha512 --iter-time 5000 --use-random --verify-passphrase luksFormat "$OPT"
-      cryptsetup open --type luks "$([[ $TRIM -eq 1 ]] && echo '--allow-discards')" "$OPT" crypt
+	  if [[ $TRIM -eq 1]]; then
+	    cryptsetup open --type luks --allow-discards "$OPT" crypt
+	  else
+	    cryptsetup open --type luks "$OPT" crypt
+	  fi
       LUKS=1
       LUKS_DISK=$(echo "${OPT}" | sed 's/\/dev\///')
       break


### PR DESCRIPTION
The output of trim check is used as the partition if TRIM isn't 1,
resulting in the partition to unlock being an empty string.

The script will then continue without opening the LUKS partition.