### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is not actively developed but *will* accept Pull Requests.
 ### With git
 - Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`
 - Get list of packages and install git: `pacman -Sy git`
-- Get the script: `git clone git://github.com/helmuthdu/aui`
+- Get the script: `git clone https://github.com/helmuthdu/aui`
 
 ### Without git
 - Increase cowspace partition: `mount -o remount,size=2G /run/archiso/cowspace`


### PR DESCRIPTION
As explained in https://github.blog/2021-09-01-improving-git-protocol-security-github/
git:// is not usable starting with 2022-03-15. Therefore fix by changing the entry to https://